### PR TITLE
libftdi1: fix licenses + add patches

### DIFF
--- a/recipes/libftdi/1.x/CMakeLists.txt
+++ b/recipes/libftdi/1.x/CMakeLists.txt
@@ -1,4 +1,4 @@
 cmake_minimum_required(VERSION 2.8)
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+include(conanbuildinfo.cmake)
 conan_basic_setup()
 add_subdirectory(source_subfolder)

--- a/recipes/libftdi/1.x/conandata.yml
+++ b/recipes/libftdi/1.x/conandata.yml
@@ -2,4 +2,11 @@ sources:
   "1.5":
     sha256: 7c7091e9c86196148bd41177b4590dccb1510bfe6cea5bf7407ff194482eb049
     url: "https://www.intra2net.com/en/developer/libftdi/download/libftdi1-1.5.tar.bz2"
-
+patches:
+  "1.5":
+    - patch_file: "patches/0001-don-t-use-global-cmake-directories.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0002-install-shared-libs-optionally.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0003-msvc-allow-libusb-libprefix.patch"
+      base_path: "source_subfolder"

--- a/recipes/libftdi/1.x/conanfile.py
+++ b/recipes/libftdi/1.x/conanfile.py
@@ -3,22 +3,28 @@ from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 
 
-class LibFtdiConan(ConanFile):
+required_conan_version = ">=1.29.1"
+
+
+class LibFtdi1Conan(ConanFile):
     name = "libftdi"
     description = "A library to talk to FTDI chips"
-    license = ["GNU LGPL v2.1"]
+    license = "LGPL-2.0-only", "GPLv2-or-later"
     topics = ("conan", "libftdi1")
     homepage = "https://www.intra2net.com/en/developer/libftdi/"
     url = "https://github.com/conan-io/conan-center-index"
-    exports_sources = ["CMakeLists.txt"]
+    exports_sources = "CMakeLists.txt", "patches/*"
     generators = "cmake", "cmake_find_package", "pkg_config"
     settings = "os", "arch", "compiler", "build_type"
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {"shared": False, "fPIC": True}
-    requires = (
-            "libusb/1.0.23",
-            "boost/1.74.0"
-            )
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
     _cmake = None
 
     @property
@@ -35,67 +41,61 @@ class LibFtdiConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
         if self.settings.os == "Macos":
             raise ConanInvalidConfiguration("Macos is not supported")
         if self.settings.compiler == "Visual Studio":
-            raise ConanInvalidConfiguration("Building with Visual Studio is not supported")
+            raise ConanInvalidConfiguration("Building with Visual Studio is not supported (due to missing gettimeofday implementation)")
 
     def build_requirements(self):
-        if not tools.which("pkg-config"):
-            self.build_requires("pkgconf/1.7.3")
+        self.build_requires("pkgconf/1.7.3")
 
-    def _patch_cmakelists(self, subfolder):
-        cmakelists_path = os.path.join(self._source_subfolder, subfolder, "CMakeLists.txt")
-        tools.replace_in_file(cmakelists_path, "CMAKE_SOURCE_DIR", "PROJECT_SOURCE_DIR", strict=False)
-        tools.replace_in_file(cmakelists_path, "CMAKE_BINARY_DIR", "PROJECT_BINARY_DIR", strict=False)
+    def requirements(self):
+        self.requires("boost/1.75.0")
+        self.requires("libusb/1.0.23")
 
     def _configure_cmake(self):
         if self._cmake:
             return self._cmake
-
         self._cmake = CMake(self)
-        options = {
+        self._cmake.definitions.update({
             "BUILD_TESTS": False,
             "EXAMPLES": False,
             "FTDI_EEPROM": False,
-            "FTDIPP" : True,
-            "STATICLIBS": not self.options.shared
-        }
-        self._cmake.definitions.update(options)
+            "FTDIPP": True,
+            "STATICLIBS": not self.options.shared,
+        })
         self._cmake.configure()
         return self._cmake
 
-
     def build(self):
-        self._patch_cmakelists("")
-        self._patch_cmakelists("ftdipp")
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
         cmake = self._configure_cmake()
         cmake.build()
 
     def package(self):
         self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
+        self.copy(pattern="COPYING*", dst="licenses", src=self._source_subfolder)
         cmake = self._configure_cmake()
         cmake.install()
         lib_folder = os.path.join(self.package_folder, "lib",)
         tools.rmdir(os.path.join(lib_folder, "cmake"))
         tools.rmdir(os.path.join(lib_folder, "pkgconfig"))
-        # STATIC config creates both static and shared libraries
-        if not self.options.shared:
-            tools.remove_files_by_mask(lib_folder, "*.so*")
 
         os.unlink(os.path.join(self.package_folder, "bin", "libftdi1-config"))
 
     def package_info(self):
         self.cpp_info.names["cmake_find_package"] = "LibFTDI1"
         self.cpp_info.names["cmake_find_package_multi"] = "LibFTDI1"
-        self.cpp_info.names["pkgconfig"] = "libftdi1"
 
-        self.cpp_info.components["ftdi"].names["cmake"] = "libftdi"
+        self.cpp_info.components["ftdi"].names["pkg_config"] = "libftdi1"
         self.cpp_info.components["ftdi"].libs = ["ftdi1"]
         self.cpp_info.components["ftdi"].requires = ["libusb::libusb"]
         self.cpp_info.components["ftdi"].includedirs.append(os.path.join("include", "libftdi1"))
 
-        self.cpp_info.components["ftdipp"].names["cmake"] = "libftdipp"
+        self.cpp_info.components["ftdi"].names["pkg_config"] = "libftdi1pp"
         self.cpp_info.components["ftdipp"].libs = ["ftdipp1"]
         self.cpp_info.components["ftdipp"].requires = ["ftdi", "boost::boost"]
         self.cpp_info.components["ftdipp"].includedirs.append(os.path.join("include", "libftdipp1"))

--- a/recipes/libftdi/1.x/patches/0001-don-t-use-global-cmake-directories.patch
+++ b/recipes/libftdi/1.x/patches/0001-don-t-use-global-cmake-directories.patch
@@ -1,0 +1,42 @@
+Based on patch by @prince-chrismc
+
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -5,7 +5,7 @@
+ set(PACKAGE libftdi1)
+ set(VERSION_STRING ${MAJOR_VERSION}.${MINOR_VERSION})
+ set(VERSION ${VERSION_STRING})
+-set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
++set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+ 
+ # CMake
+ if("${CMAKE_BUILD_TYPE}" STREQUAL "")
+@@ -100,1 +100,1 @@
+-set(CPACK_RESOURCE_FILE_LICENSE        ${CMAKE_SOURCE_DIR}/LICENSE)
++set(CPACK_RESOURCE_FILE_LICENSE        ${PROJECT_SOURCE_DIR}/LICENSE)
+@@ -165,9 +165,9 @@
+    set(libdir      ${CMAKE_INSTALL_PREFIX}/bin)
+ endif(${WIN32})
+ 
+-configure_file(${CMAKE_SOURCE_DIR}/libftdi1.pc.in ${CMAKE_BINARY_DIR}/libftdi1.pc @ONLY)
+-configure_file(${CMAKE_SOURCE_DIR}/libftdipp1.pc.in ${CMAKE_BINARY_DIR}/libftdipp1.pc @ONLY)
+-install(FILES ${CMAKE_BINARY_DIR}/libftdi1.pc ${CMAKE_BINARY_DIR}/libftdipp1.pc
++configure_file(${CMAKE_CURRENT_SOURCE_DIR}/libftdi1.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libftdi1.pc @ONLY)
++configure_file(${CMAKE_CURRENT_SOURCE_DIR}/libftdipp1.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libftdipp1.pc @ONLY)
++install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libftdi1.pc ${CMAKE_CURRENT_BINARY_DIR}/libftdipp1.pc
+         DESTINATION lib${LIB_SUFFIX}/pkgconfig)
+ 
+ if (UNIX OR MINGW)
+diff --git a/ftdipp/CMakeLists.txt b/ftdipp/CMakeLists.txt
+index fac5bcc..617199f 100644
+--- ftdipp/CMakeLists.txt
++++ ftdipp/CMakeLists.txt
+@@ -7,7 +7,7 @@
+ # Includes
+ include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR}
+ 	${CMAKE_CURRENT_SOURCE_DIR}
+-	${CMAKE_SOURCE_DIR}/src)
++	${PROJECT_SOURCE_DIR}/src)
+ 
+ include_directories(${Boost_INCLUDE_DIRS})
+ 

--- a/recipes/libftdi/1.x/patches/0002-install-shared-libs-optionally.patch
+++ b/recipes/libftdi/1.x/patches/0002-install-shared-libs-optionally.patch
@@ -1,0 +1,18 @@
+--- src/CMakeLists.txt
++++ src/CMakeLists.txt
+@@ -31,13 +31,13 @@
+ 
+ # Dependencies
+ target_link_libraries(ftdi1 ${LIBUSB_LIBRARIES})
+-
++if(NOT STATICLIBS)
+ install ( TARGETS ftdi1
+           RUNTIME DESTINATION bin
+           LIBRARY DESTINATION lib${LIB_SUFFIX}
+           ARCHIVE DESTINATION lib${LIB_SUFFIX}
+         )
+-
++endif()
+ if ( STATICLIBS )
+   add_library(ftdi1-static STATIC ${c_sources})
+   target_link_libraries(ftdi1-static ${LIBUSB_LIBRARIES})

--- a/recipes/libftdi/1.x/patches/0003-msvc-allow-libusb-libprefix.patch
+++ b/recipes/libftdi/1.x/patches/0003-msvc-allow-libusb-libprefix.patch
@@ -1,0 +1,11 @@
+--- cmake/FindUSB1.cmake
++++ cmake/FindUSB1.cmake
+@@ -26,7 +26,7 @@
+     PATH_SUFFIXES libusb-1.0
+     PATHS ${PC_LIBUSB_INCLUDEDIR} ${PC_LIBUSB_INCLUDE_DIRS})
+ 
+-  FIND_LIBRARY(LIBUSB_LIBRARIES NAMES usb-1.0
++  FIND_LIBRARY(LIBUSB_LIBRARIES NAMES usb-1.0 libusb-1.0
+     PATHS ${PC_LIBUSB_LIBDIR} ${PC_LIBUSB_LIBRARY_DIRS})
+ 
+   include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
- Modify the sources by using patches, no `tools.replace_in_files`
- use `requirements` method instead of `requires` member variable
- set `pkg_config` names for the C and C++ library
- only install the shared or static libraries, so no need to remove the dynamic libraries when building a static library)

I didn't look in the failure for macos, but it looks like the requirements of libusb, when using a static libusb library, are not passed through.
To fix this, it needs more intensive patches on `cmake/FindUSB1.cmake`.